### PR TITLE
Long Press To Expand On Profile Image

### DIFF
--- a/ThrowIT/Base.lproj/Main.storyboard
+++ b/ThrowIT/Base.lproj/Main.storyboard
@@ -516,6 +516,7 @@
                                 <gestureRecognizers/>
                                 <connections>
                                     <outletCollection property="gestureRecognizers" destination="Wax-yz-jlt" appends="YES" id="gJv-dY-XAC"/>
+                                    <outletCollection property="gestureRecognizers" destination="g25-Sc-mJB" appends="YES" id="2Iw-ZN-5Me"/>
                                 </connections>
                             </imageView>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" text="Frat Storlie" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Uol-ET-Cad">
@@ -578,6 +579,11 @@
                         <action selector="onTapProfilePicture:" destination="yo9-S4-ASC" id="BUA-Tj-foP"/>
                     </connections>
                 </tapGestureRecognizer>
+                <pongPressGestureRecognizer allowableMovement="10" minimumPressDuration="0.5" id="g25-Sc-mJB">
+                    <connections>
+                        <action selector="didLongPressOnProfileImage:" destination="yo9-S4-ASC" id="dMs-w4-xfg"/>
+                    </connections>
+                </pongPressGestureRecognizer>
             </objects>
             <point key="canvasLocation" x="2761.6822429906542" y="75.809935205183592"/>
         </scene>
@@ -1094,6 +1100,7 @@
                 <tabBarController storyboardIdentifier="ThrowerTimelineTabBarController" automaticallyAdjustsScrollViewInsets="NO" id="VZc-q8-Mz2" sceneMemberID="viewController">
                     <toolbarItems/>
                     <tabBar key="tabBar" contentMode="scaleToFill" insetsLayoutMarginsFromSafeArea="NO" id="X94-B7-qgd">
+                        <rect key="frame" x="0.0" y="0.0" width="1000" height="1000"/>
                         <autoresizingMask key="autoresizingMask"/>
                         <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                     </tabBar>

--- a/ThrowIT/Utility.h
+++ b/ThrowIT/Utility.h
@@ -91,6 +91,10 @@
 #define TAKEPHOTO @"Take Photo"
 #define CHOOSEFROMLIBRARY @"Choose from library"
 #define CANCEL @"Cancel"
+#define ORIGINALXPOSITION 1.f
+#define ORIGINALYPOSITION 1.f
+#define DEFAULTDURATION 0.3
+#define SIZEMULTIPLIER 2.5
 
 NS_ASSUME_NONNULL_BEGIN
 @interface Utility : NSObject

--- a/ThrowIT/ViewControllers/ProfileViewController.m
+++ b/ThrowIT/ViewControllers/ProfileViewController.m
@@ -70,5 +70,32 @@
     UIGraphicsEndImageContext();
     return newImage;
 }
+- (IBAction)didLongPressOnProfileImage:(id)sender {
+    UILongPressGestureRecognizer *profileImageExpand = sender;
+    CGRect profileImageframe = profileImageExpand.view.frame;
+    profileImageframe.size.height = profileImageExpand.view.frame.size.height * 2.5;
+    profileImageframe.size.width = profileImageExpand.view.frame.size.width * 2.5;
+    
+    if(profileImageExpand.state == UIGestureRecognizerStateBegan){
+        [UIView animateWithDuration:0.3 animations:^{
+            [profileImageExpand.view setOpaque:YES];
+            profileImageExpand.view.layer.zPosition = MAXFLOAT;
+            profileImageExpand.view.frame = profileImageframe;
+            profileImageExpand.view.transform = CGAffineTransformMakeTranslation(self.view.center.x - profileImageExpand.view.center.x, self.view.center.y - profileImageExpand.view.center.y);
+            
+        } completion:nil];
+    }
+    
+    profileImageframe.size.height = profileImageExpand.view.frame.size.height / 2.5;
+    profileImageframe.size.width = profileImageExpand.view.frame.size.width / 2.5;
+    if(profileImageExpand.state == UIGestureRecognizerStateEnded){
+        [UIView animateWithDuration:0.3 animations:^{
+            [profileImageExpand.view setOpaque:NO];
+            profileImageExpand.view.layer.zPosition = MAXFLOAT;
+            profileImageExpand.view.frame = profileImageframe;
+            profileImageExpand.view.transform = CGAffineTransformMakeTranslation(1.f, 1.f);
+        } completion:nil];
+    }
+}
 
 @end

--- a/ThrowIT/ViewControllers/ProfileViewController.m
+++ b/ThrowIT/ViewControllers/ProfileViewController.m
@@ -73,27 +73,21 @@
 - (IBAction)didLongPressOnProfileImage:(id)sender {
     UILongPressGestureRecognizer *profileImageExpand = sender;
     CGRect profileImageframe = profileImageExpand.view.frame;
-    profileImageframe.size.height = profileImageExpand.view.frame.size.height * 2.5;
-    profileImageframe.size.width = profileImageExpand.view.frame.size.width * 2.5;
-    
+    profileImageframe.size.height = profileImageExpand.view.frame.size.height * SIZEMULTIPLIER;
+    profileImageframe.size.width = profileImageExpand.view.frame.size.width * SIZEMULTIPLIER;
     if(profileImageExpand.state == UIGestureRecognizerStateBegan){
-        [UIView animateWithDuration:0.3 animations:^{
-            [profileImageExpand.view setOpaque:YES];
+        [UIView animateWithDuration:DEFAULTDURATION animations:^{
             profileImageExpand.view.layer.zPosition = MAXFLOAT;
             profileImageExpand.view.frame = profileImageframe;
             profileImageExpand.view.transform = CGAffineTransformMakeTranslation(self.view.center.x - profileImageExpand.view.center.x, self.view.center.y - profileImageExpand.view.center.y);
-            
         } completion:nil];
     }
-    
-    profileImageframe.size.height = profileImageExpand.view.frame.size.height / 2.5;
-    profileImageframe.size.width = profileImageExpand.view.frame.size.width / 2.5;
+    profileImageframe.size.height = profileImageExpand.view.frame.size.height / SIZEMULTIPLIER;
+    profileImageframe.size.width = profileImageExpand.view.frame.size.width / SIZEMULTIPLIER;
     if(profileImageExpand.state == UIGestureRecognizerStateEnded){
-        [UIView animateWithDuration:0.3 animations:^{
-            [profileImageExpand.view setOpaque:NO];
-            profileImageExpand.view.layer.zPosition = MAXFLOAT;
+        [UIView animateWithDuration:DEFAULTDURATION animations:^{
             profileImageExpand.view.frame = profileImageframe;
-            profileImageExpand.view.transform = CGAffineTransformMakeTranslation(1.f, 1.f);
+            profileImageExpand.view.transform = CGAffineTransformMakeTranslation(ORIGINALXPOSITION, ORIGINALYPOSITION);
         } completion:nil];
     }
 }

--- a/ThrowIT/ViewControllers/ProfileViewController.m
+++ b/ThrowIT/ViewControllers/ProfileViewController.m
@@ -70,6 +70,7 @@
     UIGraphicsEndImageContext();
     return newImage;
 }
+
 - (IBAction)didLongPressOnProfileImage:(id)sender {
     UILongPressGestureRecognizer *profileImageExpand = sender;
     CGRect profileImageframe = profileImageExpand.view.frame;


### PR DESCRIPTION
Users can now long press on profile image to expand and centralize the image. Releasing takes the image back to its original orientation. Please find demo video below:
https://drive.google.com/file/d/1NDs98JZYaxvAua3CyAi3I6R9nsLcZs1q/view?usp=sharing