### PR TITLE
Date picker integration + register attendance

### DIFF
--- a/ThrowIT.xcodeproj/project.pbxproj
+++ b/ThrowIT.xcodeproj/project.pbxproj
@@ -21,6 +21,7 @@
 		891EF8E5287551DD00F5947E /* SignUpViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 891EF8E4287551DD00F5947E /* SignUpViewController.m */; };
 		891EF8E82875530400F5947E /* TimelineViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 891EF8E72875530400F5947E /* TimelineViewController.m */; };
 		891EF8EB287554D300F5947E /* LoginViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 891EF8EA287554D300F5947E /* LoginViewController.m */; };
+		8922000C289C8CAA00EDF9A1 /* Check In.m in Sources */ = {isa = PBXBuildFile; fileRef = 8922000B289C8CAA00EDF9A1 /* Check In.m */; };
 		893969262884F1F9004DD10E /* ProfileViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 893969252884F1F9004DD10E /* ProfileViewController.m */; };
 		898244E728762FCC00744255 /* PartyCell.m in Sources */ = {isa = PBXBuildFile; fileRef = 898244E628762FCC00744255 /* PartyCell.m */; };
 		898244ED28775E6400744255 /* TopPartyCell.m in Sources */ = {isa = PBXBuildFile; fileRef = 898244EC28775E6400744255 /* TopPartyCell.m */; };
@@ -86,6 +87,8 @@
 		891EF8E72875530400F5947E /* TimelineViewController.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = TimelineViewController.m; sourceTree = "<group>"; };
 		891EF8E9287554D300F5947E /* LoginViewController.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = LoginViewController.h; sourceTree = "<group>"; };
 		891EF8EA287554D300F5947E /* LoginViewController.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = LoginViewController.m; sourceTree = "<group>"; };
+		8922000A289C8CAA00EDF9A1 /* Check In.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "Check In.h"; sourceTree = "<group>"; };
+		8922000B289C8CAA00EDF9A1 /* Check In.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = "Check In.m"; sourceTree = "<group>"; };
 		893969242884F1F9004DD10E /* ProfileViewController.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ProfileViewController.h; sourceTree = "<group>"; };
 		893969252884F1F9004DD10E /* ProfileViewController.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = ProfileViewController.m; sourceTree = "<group>"; };
 		898244E528762FCC00744255 /* PartyCell.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = PartyCell.h; sourceTree = "<group>"; };
@@ -255,6 +258,8 @@
 		891EF8EF28760ECF00F5947E /* Models */ = {
 			isa = PBXGroup;
 			children = (
+				8922000A289C8CAA00EDF9A1 /* Check In.h */,
+				8922000B289C8CAA00EDF9A1 /* Check In.m */,
 				898244EE28779F9300744255 /* Party.h */,
 				898244EF28779F9300744255 /* Party.m */,
 				898244F128779FF300744255 /* Thrower.h */,
@@ -513,6 +518,7 @@
 				89855E2C289302A4006D1A13 /* ThrowerProfileViewController.m in Sources */,
 				898244ED28775E6400744255 /* TopPartyCell.m in Sources */,
 				89824503287D104400744255 /* ThrowerPartyCell.m in Sources */,
+				8922000C289C8CAA00EDF9A1 /* Check In.m in Sources */,
 				89AC10FA288A855F00F35820 /* PartyFilterViewController.m in Sources */,
 				898244F9287D084300744255 /* ThrowerTimelineViewController.m in Sources */,
 				891EF8AE286E519000F5947E /* SceneDelegate.m in Sources */,

--- a/ThrowIT.xcworkspace/xcuserdata/oore.xcuserdatad/xcdebugger/Breakpoints_v2.xcbkptlist
+++ b/ThrowIT.xcworkspace/xcuserdata/oore.xcuserdatad/xcdebugger/Breakpoints_v2.xcbkptlist
@@ -3,4 +3,22 @@
    uuid = "486BDDBA-F041-4ECB-9E71-D5BDEE168A67"
    type = "0"
    version = "2.0">
+   <Breakpoints>
+      <BreakpointProxy
+         BreakpointExtensionID = "Xcode.Breakpoint.FileBreakpoint">
+         <BreakpointContent
+            uuid = "593F7DE3-3EB1-457C-8CA6-0C2ED7878F38"
+            shouldBeEnabled = "Yes"
+            ignoreCount = "0"
+            continueAfterRunningActions = "No"
+            filePath = "ThrowIT/ViewControllers/DetailsViewController.m"
+            startingColumnNumber = "9223372036854775807"
+            endingColumnNumber = "9223372036854775807"
+            startingLineNumber = "66"
+            endingLineNumber = "66"
+            landmarkName = "-didTapCheckIn:"
+            landmarkType = "7">
+         </BreakpointContent>
+      </BreakpointProxy>
+   </Breakpoints>
 </Bucket>

--- a/ThrowIT.xcworkspace/xcuserdata/oore.xcuserdatad/xcdebugger/Breakpoints_v2.xcbkptlist
+++ b/ThrowIT.xcworkspace/xcuserdata/oore.xcuserdatad/xcdebugger/Breakpoints_v2.xcbkptlist
@@ -3,22 +3,4 @@
    uuid = "486BDDBA-F041-4ECB-9E71-D5BDEE168A67"
    type = "0"
    version = "2.0">
-   <Breakpoints>
-      <BreakpointProxy
-         BreakpointExtensionID = "Xcode.Breakpoint.FileBreakpoint">
-         <BreakpointContent
-            uuid = "593F7DE3-3EB1-457C-8CA6-0C2ED7878F38"
-            shouldBeEnabled = "Yes"
-            ignoreCount = "0"
-            continueAfterRunningActions = "No"
-            filePath = "ThrowIT/ViewControllers/DetailsViewController.m"
-            startingColumnNumber = "9223372036854775807"
-            endingColumnNumber = "9223372036854775807"
-            startingLineNumber = "66"
-            endingLineNumber = "66"
-            landmarkName = "-didTapCheckIn:"
-            landmarkType = "7">
-         </BreakpointContent>
-      </BreakpointProxy>
-   </Breakpoints>
 </Bucket>

--- a/ThrowIT/Base.lproj/Main.storyboard
+++ b/ThrowIT/Base.lproj/Main.storyboard
@@ -1265,7 +1265,6 @@
                                 <state key="normal" title="Button"/>
                                 <buttonConfiguration key="configuration" style="plain" title="Check in">
                                     <backgroundConfiguration key="background">
-                                        <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                                         <color key="strokeColor" systemColor="labelColor"/>
                                     </backgroundConfiguration>
                                     <color key="baseForegroundColor" systemColor="labelColor"/>

--- a/ThrowIT/Base.lproj/Main.storyboard
+++ b/ThrowIT/Base.lproj/Main.storyboard
@@ -886,6 +886,14 @@
                                                             <constraint firstAttribute="height" constant="1" id="oCz-j4-uEm"/>
                                                         </constraints>
                                                     </view>
+                                                    <view hidden="YES" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="2fW-MA-Rpm">
+                                                        <rect key="frame" x="90" y="117" width="38" height="11"/>
+                                                        <color key="backgroundColor" red="0.0" green="0.76942896839999997" blue="0.085222583020000006" alpha="1" colorSpace="custom" customColorSpace="displayP3"/>
+                                                        <constraints>
+                                                            <constraint firstAttribute="width" constant="38" id="1gF-gr-38J"/>
+                                                            <constraint firstAttribute="height" constant="11" id="7Sj-F0-Snx"/>
+                                                        </constraints>
+                                                    </view>
                                                 </subviews>
                                                 <color key="backgroundColor" red="0.61568629740000003" green="0.52941179279999995" blue="0.84313726430000002" alpha="1" colorSpace="custom" customColorSpace="displayP3"/>
                                                 <constraints>
@@ -897,6 +905,7 @@
                                                     <constraint firstAttribute="trailing" secondItem="8qy-bE-8iA" secondAttribute="trailing" constant="10" id="8vB-2q-F7l"/>
                                                     <constraint firstItem="K6D-Aj-72B" firstAttribute="centerY" secondItem="rvn-rW-SAH" secondAttribute="centerY" id="AFF-kg-eR4"/>
                                                     <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="5VP-pO-MZ6" secondAttribute="trailing" constant="8" id="AGC-fD-CVl"/>
+                                                    <constraint firstAttribute="bottom" secondItem="2fW-MA-Rpm" secondAttribute="bottom" id="GJf-Ep-K7F"/>
                                                     <constraint firstItem="rvn-rW-SAH" firstAttribute="leading" secondItem="8qy-bE-8iA" secondAttribute="leading" id="HX6-VF-6Ys"/>
                                                     <constraint firstItem="K6D-Aj-72B" firstAttribute="leading" secondItem="rvn-rW-SAH" secondAttribute="trailing" constant="4" id="HaP-LJ-9UR"/>
                                                     <constraint firstItem="8qy-bE-8iA" firstAttribute="leading" secondItem="ezw-yu-tls" secondAttribute="leading" constant="10" id="M4q-rX-vOq"/>
@@ -904,6 +913,7 @@
                                                     <constraint firstAttribute="trailing" secondItem="5Pq-xO-uKV" secondAttribute="trailing" constant="10" id="dVm-R8-fCS"/>
                                                     <constraint firstItem="5VP-pO-MZ6" firstAttribute="leading" secondItem="K6D-Aj-72B" secondAttribute="trailing" constant="4" id="gvc-Et-qzD"/>
                                                     <constraint firstItem="jPe-lp-m9r" firstAttribute="centerY" secondItem="Kfv-oq-ZsO" secondAttribute="centerY" id="jk8-Ed-79n"/>
+                                                    <constraint firstAttribute="trailing" secondItem="2fW-MA-Rpm" secondAttribute="trailing" constant="0.99999999999997158" id="lsc-ji-8ls"/>
                                                     <constraint firstItem="Kfv-oq-ZsO" firstAttribute="leading" secondItem="ezw-yu-tls" secondAttribute="leading" constant="10" id="mSz-ek-tL7"/>
                                                     <constraint firstItem="5VP-pO-MZ6" firstAttribute="bottom" secondItem="rvn-rW-SAH" secondAttribute="bottom" id="nfs-ee-ZWH"/>
                                                     <constraint firstItem="jPe-lp-m9r" firstAttribute="top" secondItem="ezw-yu-tls" secondAttribute="top" constant="16" id="r2P-vS-1R0"/>
@@ -912,6 +922,7 @@
                                             </collectionViewCellContentView>
                                             <gestureRecognizers/>
                                             <connections>
+                                                <outlet property="checkInTag" destination="2fW-MA-Rpm" id="P5O-Yf-627"/>
                                                 <outlet property="goingButton" destination="K6D-Aj-72B" id="CPk-Eg-W7Z"/>
                                                 <outlet property="goingCountLabel" destination="rvn-rW-SAH" id="ALk-AQ-Ymv"/>
                                                 <outlet property="partyDescriptionLabel" destination="8qy-bE-8iA" id="OYB-CS-h4T"/>
@@ -996,6 +1007,14 @@
                                                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                                     <color key="backgroundColor" systemColor="labelColor"/>
                                                 </view>
+                                                <view hidden="YES" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Cv9-Hr-hgO">
+                                                    <rect key="frame" x="390" y="94.999999999999943" width="38" height="11"/>
+                                                    <color key="backgroundColor" red="0.0" green="0.76942896842956543" blue="0.085222583021309917" alpha="1" colorSpace="custom" customColorSpace="displayP3"/>
+                                                    <constraints>
+                                                        <constraint firstAttribute="width" constant="38" id="JEm-UQ-xP7"/>
+                                                        <constraint firstAttribute="height" constant="11" id="Z36-V5-nst"/>
+                                                    </constraints>
+                                                </view>
                                             </subviews>
                                             <color key="backgroundColor" red="0.54901963470000004" green="0.47450977560000002" blue="0.75686275960000005" alpha="1" colorSpace="custom" customColorSpace="displayP3"/>
                                             <constraints>
@@ -1024,6 +1043,8 @@
                                                 <constraint firstItem="bqB-qT-VmZ" firstAttribute="leading" secondItem="mlC-3g-wJ6" secondAttribute="trailing" constant="4" id="hAB-2q-rvs"/>
                                                 <constraint firstItem="Bnq-Oz-Yub" firstAttribute="leading" relation="greaterThanOrEqual" secondItem="fQd-Tk-xLn" secondAttribute="trailing" constant="16" id="iEv-fl-Sbt"/>
                                                 <constraint firstItem="mlC-3g-wJ6" firstAttribute="top" secondItem="Ugx-vf-K6a" secondAttribute="top" constant="8" id="lsA-Rr-8oc"/>
+                                                <constraint firstAttribute="bottom" secondItem="Cv9-Hr-hgO" secondAttribute="bottom" id="mhY-Zf-ntd"/>
+                                                <constraint firstAttribute="trailing" secondItem="Cv9-Hr-hgO" secondAttribute="trailing" id="pjO-sN-edc"/>
                                                 <constraint firstItem="Jd4-vs-7CF" firstAttribute="leading" secondItem="Ugx-vf-K6a" secondAttribute="leading" constant="10" id="pxU-zF-7BB"/>
                                                 <constraint firstItem="Lp1-ip-iWu" firstAttribute="leading" secondItem="2Qn-Nn-HH0" secondAttribute="trailing" constant="4" id="sUw-jl-dcm"/>
                                                 <constraint firstItem="bqB-qT-VmZ" firstAttribute="top" secondItem="mlC-3g-wJ6" secondAttribute="top" id="t64-lq-4kY"/>
@@ -1035,6 +1056,7 @@
                                         </tableViewCellContentView>
                                         <gestureRecognizers/>
                                         <connections>
+                                            <outlet property="checkInTag" destination="Cv9-Hr-hgO" id="fS6-ta-WEC"/>
                                             <outlet property="goingButton" destination="Bnq-Oz-Yub" id="Gmd-8Z-ZI5"/>
                                             <outlet property="partyDescription" destination="fQd-Tk-xLn" id="NSP-cY-xvZ"/>
                                             <outlet property="partyDistance" destination="45Z-F5-ZLA" id="tGa-g9-zpy"/>

--- a/ThrowIT/Base.lproj/Main.storyboard
+++ b/ThrowIT/Base.lproj/Main.storyboard
@@ -305,7 +305,7 @@
                                                     <nil key="highlightedColor"/>
                                                 </label>
                                                 <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" ambiguous="YES" translatesAutoresizingMaskIntoConstraints="NO" id="ToF-ye-Jf3" customClass="PFImageView">
-                                                    <rect key="frame" x="20" y="71" width="388" height="218"/>
+                                                    <rect key="frame" x="0.0" y="71" width="428" height="218"/>
                                                     <color key="backgroundColor" systemColor="labelColor"/>
                                                     <color key="tintColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                     <constraints>
@@ -328,19 +328,19 @@
                                             <color key="backgroundColor" red="0.94901961089999998" green="0.7607843876" blue="0.60000002379999995" alpha="1" colorSpace="custom" customColorSpace="displayP3"/>
                                             <color key="tintColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                             <constraints>
-                                                <constraint firstItem="ToF-ye-Jf3" firstAttribute="leading" secondItem="Q0v-Gn-8uf" secondAttribute="leading" id="4jd-hc-Qpo"/>
-                                                <constraint firstItem="ToF-ye-Jf3" firstAttribute="trailing" secondItem="Q0v-Gn-8uf" secondAttribute="trailing" id="4my-KT-t6k"/>
                                                 <constraint firstItem="OlK-nw-V0z" firstAttribute="leading" secondItem="Q0v-Gn-8uf" secondAttribute="leading" id="B3M-u9-W7I"/>
-                                                <constraint firstItem="OlK-nw-V0z" firstAttribute="top" secondItem="ToF-ye-Jf3" secondAttribute="bottom" constant="8" id="E5W-3w-26z"/>
+                                                <constraint firstItem="OlK-nw-V0z" firstAttribute="top" secondItem="ToF-ye-Jf3" secondAttribute="bottom" constant="12" id="E5W-3w-26z"/>
                                                 <constraint firstItem="09U-9n-SqB" firstAttribute="leading" secondItem="Q0v-Gn-8uf" secondAttribute="leading" id="E9k-j8-14K"/>
                                                 <constraint firstItem="09U-9n-SqB" firstAttribute="top" secondItem="Q0v-Gn-8uf" secondAttribute="bottom" constant="8" id="EAn-ps-fH3"/>
+                                                <constraint firstItem="ToF-ye-Jf3" firstAttribute="leading" secondItem="ice-t6-zpx" secondAttribute="leading" id="Jm2-MU-zT4"/>
                                                 <constraint firstItem="09U-9n-SqB" firstAttribute="trailing" secondItem="Q0v-Gn-8uf" secondAttribute="trailing" id="KQv-Wg-sBU"/>
                                                 <constraint firstItem="ToF-ye-Jf3" firstAttribute="top" secondItem="09U-9n-SqB" secondAttribute="bottom" constant="8" id="Mre-a0-Oew"/>
                                                 <constraint firstItem="OlK-nw-V0z" firstAttribute="trailing" secondItem="Q0v-Gn-8uf" secondAttribute="trailing" id="OCo-sp-BOa"/>
                                                 <constraint firstAttribute="trailing" secondItem="Q0v-Gn-8uf" secondAttribute="trailing" constant="20" symbolic="YES" id="bPv-Hc-xjX"/>
+                                                <constraint firstAttribute="trailing" secondItem="ToF-ye-Jf3" secondAttribute="trailing" id="cjX-iu-wic"/>
                                                 <constraint firstItem="Q0v-Gn-8uf" firstAttribute="leading" secondItem="ice-t6-zpx" secondAttribute="leading" constant="20" symbolic="YES" id="jPT-O2-ciU"/>
                                                 <constraint firstItem="Q0v-Gn-8uf" firstAttribute="top" secondItem="ice-t6-zpx" secondAttribute="top" constant="8" id="m0H-h2-Y75"/>
-                                                <constraint firstAttribute="bottom" secondItem="OlK-nw-V0z" secondAttribute="bottom" constant="8" id="z3B-zm-9RB"/>
+                                                <constraint firstAttribute="bottom" secondItem="OlK-nw-V0z" secondAttribute="bottom" constant="12" id="z3B-zm-9RB"/>
                                             </constraints>
                                         </tableViewCellContentView>
                                         <connections>

--- a/ThrowIT/Base.lproj/Main.storyboard
+++ b/ThrowIT/Base.lproj/Main.storyboard
@@ -298,28 +298,28 @@
                                             <rect key="frame" x="0.0" y="0.0" width="428" height="374"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
-                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" ambiguous="YES" text="Party Theme" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="09U-9n-SqB">
-                                                    <rect key="frame" x="20" y="41.333333333333343" width="388" height="21.666666666666664"/>
+                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Party Theme" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="09U-9n-SqB">
+                                                    <rect key="frame" x="20" y="16" width="388" height="0.0"/>
                                                     <fontDescription key="fontDescription" type="system" pointSize="18"/>
                                                     <nil key="textColor"/>
                                                     <nil key="highlightedColor"/>
                                                 </label>
-                                                <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" ambiguous="YES" translatesAutoresizingMaskIntoConstraints="NO" id="ToF-ye-Jf3" customClass="PFImageView">
-                                                    <rect key="frame" x="0.0" y="71" width="428" height="218"/>
+                                                <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="ToF-ye-Jf3" customClass="PFImageView">
+                                                    <rect key="frame" x="0.0" y="24" width="428" height="326"/>
                                                     <color key="backgroundColor" systemColor="labelColor"/>
                                                     <color key="tintColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                     <constraints>
-                                                        <constraint firstAttribute="height" constant="218" id="qSw-16-dHW"/>
+                                                        <constraint firstAttribute="height" constant="450" id="qSw-16-dHW"/>
                                                     </constraints>
                                                 </imageView>
-                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" ambiguous="YES" text="Party Name" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Q0v-Gn-8uf">
-                                                    <rect key="frame" x="20" y="8" width="388" height="25.333333333333329"/>
+                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Party Name" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Q0v-Gn-8uf">
+                                                    <rect key="frame" x="20" y="8" width="388" height="0.0"/>
                                                     <fontDescription key="fontDescription" type="system" weight="semibold" pointSize="21"/>
                                                     <nil key="textColor"/>
                                                     <nil key="highlightedColor"/>
                                                 </label>
-                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" ambiguous="YES" text=" 2 - 4" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="OlK-nw-V0z">
-                                                    <rect key="frame" x="20" y="310" width="388" height="43"/>
+                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text=" 2 - 4" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="OlK-nw-V0z">
+                                                    <rect key="frame" x="20" y="362" width="388" height="0.0"/>
                                                     <fontDescription key="fontDescription" type="system" weight="thin" pointSize="36"/>
                                                     <nil key="textColor"/>
                                                     <nil key="highlightedColor"/>
@@ -918,7 +918,6 @@
                                                 <outlet property="partyNameLabel" destination="jPe-lp-m9r" id="gRF-bw-EHv"/>
                                                 <outlet property="partyRatingLabel" destination="5VP-pO-MZ6" id="0O9-2e-JtZ"/>
                                                 <outlet property="throwerProfilePicture" destination="Kfv-oq-ZsO" id="zGC-zL-WNO"/>
-                                                <segue destination="Zk2-eP-YQZ" kind="presentation" identifier="toDetailsViewControllerForCollectionCell" id="s2E-pg-iGe"/>
                                             </connections>
                                         </collectionViewCell>
                                     </cells>
@@ -1240,10 +1239,15 @@
                                 <nil key="highlightedColor"/>
                             </label>
                             <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="trailing" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="2PE-Ii-mEX">
-                                <rect key="frame" x="293" y="120" width="115" height="33"/>
+                                <rect key="frame" x="318" y="120" width="90" height="33"/>
                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                 <state key="normal" title="Button"/>
-                                <buttonConfiguration key="configuration" style="plain" title="Directions"/>
+                                <buttonConfiguration key="configuration" style="plain" title="Directions">
+                                    <backgroundConfiguration key="background">
+                                        <color key="strokeColor" systemColor="labelColor"/>
+                                    </backgroundConfiguration>
+                                    <color key="baseForegroundColor" systemColor="labelColor"/>
+                                </buttonConfiguration>
                                 <connections>
                                     <action selector="goToMapDirections:" destination="Zk2-eP-YQZ" eventType="touchUpInside" id="50Z-TW-kWN"/>
                                 </connections>
@@ -1255,6 +1259,21 @@
                                     <constraint firstAttribute="height" constant="388" id="ujQ-dw-QbV"/>
                                 </constraints>
                             </view>
+                            <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="B1C-dX-EKZ">
+                                <rect key="frame" x="174" y="744" width="81" height="31"/>
+                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                <state key="normal" title="Button"/>
+                                <buttonConfiguration key="configuration" style="plain" title="Check in">
+                                    <backgroundConfiguration key="background">
+                                        <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                                        <color key="strokeColor" systemColor="labelColor"/>
+                                    </backgroundConfiguration>
+                                    <color key="baseForegroundColor" systemColor="labelColor"/>
+                                </buttonConfiguration>
+                                <connections>
+                                    <action selector="didTapCheckIn:" destination="Zk2-eP-YQZ" eventType="touchUpInside" id="uYD-6a-sPe"/>
+                                </connections>
+                            </button>
                         </subviews>
                         <viewLayoutGuide key="safeArea" id="ZhC-9l-zFZ"/>
                         <color key="backgroundColor" systemColor="systemBackgroundColor"/>
@@ -1265,13 +1284,14 @@
                     </view>
                     <navigationItem key="navigationItem" id="bGk-0K-4hl"/>
                     <connections>
+                        <outlet property="checkInButton" destination="B1C-dX-EKZ" id="UHg-tF-khz"/>
                         <outlet property="partyNameLabel" destination="U9f-7n-0lL" id="PwU-0Y-dW0"/>
                         <outlet property="viewForMapView" destination="O6P-Uy-1Qg" id="xBE-4P-aWE"/>
                     </connections>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="2ux-lS-mZs" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="4022" y="-233"/>
+            <point key="canvasLocation" x="4021.9626168224295" y="-233.26133909287259"/>
         </scene>
         <!--Parties-->
         <scene sceneID="daK-jZ-Sxb">

--- a/ThrowIT/Keys.plist
+++ b/ThrowIT/Keys.plist
@@ -5,8 +5,8 @@
 	<key>google_Maps_API_Key</key>
 	<string>AIzaSyD7hKoIbEncEISSrBMPQtgnsnFddzr8DHk</string>
 	<key>parse_Client_Key</key>
-	<string>ixtHG75gIRrNGlhjrDMA8U97ytJCSkXyfEt8tr0X</string>
+	<string>xT9LCOSNQUsDOvXobNPG2HqPGKCKffuXQBwa7Bqy</string>
 	<key>parse_ApplicationId</key>
-	<string>v8uByh91t6JU8Cc9c2cIy1yV5Ykj6kawRdSeGDEg</string>
+	<string>TrtKZjE2MdwvtjeoisicNFOoV43c6ZZef6SP8rBQ</string>
 </dict>
 </plist>

--- a/ThrowIT/Models/Check In.h
+++ b/ThrowIT/Models/Check In.h
@@ -8,6 +8,7 @@
 #import <Foundation/Foundation.h>
 #import "Parse/Parse.h"
 #import "Party.h"
+#import "Utility.h"
 
 NS_ASSUME_NONNULL_BEGIN
 
@@ -15,7 +16,8 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, strong) PFUser *user;
 @property (nonatomic, strong) Party *party;
 
--(void)postNewCheckInForParty:(Party *) party withCompletion: (PFBooleanResultBlock  _Nullable)completion;
++(void)postNewCheckInForParty:(Party *) party withCompletion: (PFBooleanResultBlock  _Nullable)completion;
++(void)userIsCheckedIn:(Party *) party withCompletion:(void (^)(BOOL checkInExists))completion;
 @end
 
 NS_ASSUME_NONNULL_END

--- a/ThrowIT/Models/Check In.h
+++ b/ThrowIT/Models/Check In.h
@@ -1,0 +1,21 @@
+//
+//  Check In.h
+//  ThrowIT
+//
+//  Created by Oore Fasawe on 8/4/22.
+//
+
+#import <Foundation/Foundation.h>
+#import "Parse/Parse.h"
+#import "Party.h"
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface Check_In : PFObject <PFSubclassing>
+@property (nonatomic, strong) PFUser *user;
+@property (nonatomic, strong) Party *party;
+
+-(void)postNewCheckInForParty:(Party *) party withCompletion: (PFBooleanResultBlock  _Nullable)completion;
+@end
+
+NS_ASSUME_NONNULL_END

--- a/ThrowIT/Models/Check In.m
+++ b/ThrowIT/Models/Check In.m
@@ -12,13 +12,30 @@
 @dynamic party;
 
 + (nonnull NSString *)parseClassName {
-    return @"Check In";
+    return @"Check_In";
 }
 
--(void)postNewCheckInForParty:(Party *) party withCompletion: (PFBooleanResultBlock  _Nullable)completion{
++(void)postNewCheckInForParty:(Party *) party withCompletion: (PFBooleanResultBlock  _Nullable)completion{
     Check_In *checkIn = [Check_In new];
     checkIn.user = [PFUser currentUser];
     checkIn.party = party;
     [checkIn saveInBackgroundWithBlock: completion];
+}
+
++(void)userIsCheckedIn:(Party *) party withCompletion:(void (^)(BOOL checkInExists))completion{
+    PFQuery *checkInQuery = [PFQuery queryWithClassName:@"Check_In"];
+    [checkInQuery whereKey:USER equalTo:[PFUser currentUser]];
+    [checkInQuery whereKey:PARTYKEY equalTo:party];
+    [checkInQuery countObjectsInBackgroundWithBlock:^(int number, NSError * _Nullable error) {
+        if(!error)
+        {
+            if(number)
+                completion(YES);
+            else
+                completion(NO);
+        }
+        else
+            NSLog(@"ERROR: %@", error.localizedDescription);
+    }];
 }
 @end

--- a/ThrowIT/Models/Check In.m
+++ b/ThrowIT/Models/Check In.m
@@ -1,0 +1,24 @@
+//
+//  Check In.m
+//  ThrowIT
+//
+//  Created by Oore Fasawe on 8/4/22.
+//
+
+#import "Check In.h"
+
+@implementation Check_In
+@dynamic user;
+@dynamic party;
+
++ (nonnull NSString *)parseClassName {
+    return @"Check In";
+}
+
+-(void)postNewCheckInForParty:(Party *) party withCompletion: (PFBooleanResultBlock  _Nullable)completion{
+    Check_In *checkIn = [Check_In new];
+    checkIn.user = [PFUser currentUser];
+    checkIn.party = party;
+    [checkIn saveInBackgroundWithBlock: completion];
+}
+@end

--- a/ThrowIT/Models/Party.h
+++ b/ThrowIT/Models/Party.h
@@ -34,7 +34,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 + (void) postNewParty:(Party *) party withPartyName:( NSString * _Nullable )partyName withDescription:(NSString * _Nullable)partyDescription withStartTime:(NSDate * _Nullable)startTime withEndTime:(NSDate * _Nullable)endTime withSchoolName:(NSString * _Nullable)school withPartyPhoto:(UIImage* _Nullable)partyPhoto withLocationName:(NSString *)partyLocationName withLocationAddress:(NSString *)partyLocationAddress withLocationCoordinate:(CLLocationCoordinate2D) partyCoordinate withLocationId:(NSString *) partyLocationId withCompletion: (PFBooleanResultBlock  _Nullable)completion;
 + (PFFileObject *)getPFFileFromImage: (UIImage * _Nullable)image;
-
+-(BOOL)isGoingOn;
 
 @end
 

--- a/ThrowIT/Models/Party.m
+++ b/ThrowIT/Models/Party.m
@@ -70,5 +70,12 @@
     return [PFFileObject fileObjectWithName:PARSEIMAGEDEFAULTFILENAME data:imageData];
 }
 
+-(BOOL)isGoingOn{
+    if([[NSDate now] earlierDate:self.startTime] == self.startTime && [[NSDate now] laterDate:self.endTime] == self.endTime)
+        return true;
+    else
+        return false;
+}
+
 
 @end

--- a/ThrowIT/Models/Party.m
+++ b/ThrowIT/Models/Party.m
@@ -54,7 +54,6 @@
     newParty.rating = 0;
     newParty.partyLocationId = partyLocationId;
     [newParty saveInBackgroundWithBlock: completion];
-
 }
 
 + (PFFileObject *)getPFFileFromImage: (UIImage * _Nullable)image {

--- a/ThrowIT/ViewComponents/PartyCell.h
+++ b/ThrowIT/ViewComponents/PartyCell.h
@@ -26,5 +26,6 @@ NS_ASSUME_NONNULL_BEGIN
 @property (strong, nonatomic) IBOutlet UIButton *goingButton;
 @property (nonatomic, strong) CoreHapticsGenerator *soundGenerator;
 - (IBAction)didTapLike:(id)sender;
+@property (strong, nonatomic) IBOutlet UIView *checkInTag;
 NS_ASSUME_NONNULL_END
 @end

--- a/ThrowIT/ViewComponents/TopPartyCell.h
+++ b/ThrowIT/ViewComponents/TopPartyCell.h
@@ -22,6 +22,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property (strong, nonatomic) IBOutlet UILabel *partyRatingLabel;
 @property (strong, nonatomic) IBOutlet PFImageView *throwerProfilePicture;
 @property (nonatomic, strong) CoreHapticsGenerator *soundGenerator;
+@property (strong, nonatomic) IBOutlet UIView *checkInTag;
 - (IBAction)didTapLike:(id)sender;
 @end
 

--- a/ThrowIT/ViewControllers/CreatePartyViewController.m
+++ b/ThrowIT/ViewControllers/CreatePartyViewController.m
@@ -51,7 +51,7 @@
     }
     else{
         Party *party = [Party new];
-        [Party postNewParty:party withPartyName:self.partyNameField.text withDescription:self.partyDescriptionField.text withStartTime:self.partyDateStart withEndTime:self.partyDateEnd withSchoolName:nil withBackGroundImage:nil withLocationName:self.partyLocationName withLocationAddress:self.partyLocationField.text withLocationCoordinate:self.partyCoordinate withLocationId:self.partyLocationId withCompletion:^(BOOL succeeded, NSError * _Nullable error) {
+        [Party postNewParty:party withPartyName:self.partyNameField.text withDescription:self.partyDescriptionField.text withStartTime:self.partyDateStart withEndTime:self.partyDateEnd withSchoolName:nil withPartyPhoto:self.partyImageView.image withLocationName:self.partyLocationName withLocationAddress:self.partyLocationField.text withLocationCoordinate:self.partyCoordinate withLocationId:self.partyLocationId withCompletion:^(BOOL succeeded, NSError * _Nullable error) {
             if(error){
                 NSLog(@"%@", error.localizedDescription);
             }

--- a/ThrowIT/ViewControllers/CreatePartyViewController.m
+++ b/ThrowIT/ViewControllers/CreatePartyViewController.m
@@ -108,6 +108,10 @@ didFailAutocompleteWithError:(NSError *)error {
 
 - (IBAction)didSetPartyStartDate:(id)sender {
     UIDatePicker* datePicker = sender;
+    if([datePicker.date earlierDate:[NSDate now]] == datePicker.date){
+        //TODO: show error: @set start date to be later than current date
+        datePicker.date = [NSDate now];
+    }
     self.partyDateStart = datePicker.date;
     self.partyDateTimePickerEnd.date = [NSDate dateWithTimeInterval:TIMEINTERVAL sinceDate: datePicker.date];
     self.partyDateEnd = self.partyDateTimePickerEnd.date;
@@ -115,6 +119,10 @@ didFailAutocompleteWithError:(NSError *)error {
 
 - (IBAction)didSetPartyEndDate:(id)sender {
     UIDatePicker* datePicker = sender;
+    if([datePicker.date earlierDate:self.partyDateTimePicker.date] == datePicker.date){
+        //TODO: show error: @set end date to be later than start date
+        datePicker.date = [NSDate dateWithTimeInterval:TIMEINTERVAL sinceDate: self.partyDateTimePicker.date];;
+    }
     self.partyDateTimePickerEnd.date = datePicker.date;
 }
 

--- a/ThrowIT/ViewControllers/CreatePartyViewController.m
+++ b/ThrowIT/ViewControllers/CreatePartyViewController.m
@@ -46,7 +46,7 @@
 }
 
 - (IBAction)throwParty:(id)sender {
-    if([self.partyNameField.text isEqual:EMPTY] || [self.partyDescriptionField.text isEqual:EMPTY] || [self.partyLocationField.text isEqual:EMPTY]){
+    if([self.partyNameField.text isEqual:EMPTY] || [self.partyDescriptionField.text isEqual:EMPTY] || [self.partyLocationField.text isEqual:EMPTY] || self.partyDateStart){
         //TODO: show missing fields alert
     }
     else{

--- a/ThrowIT/ViewControllers/DetailsViewController.h
+++ b/ThrowIT/ViewControllers/DetailsViewController.h
@@ -14,6 +14,7 @@ NS_ASSUME_NONNULL_BEGIN
 @interface DetailsViewController : UIViewController
 @property (nonatomic, strong) Party *party;
 @property (nonatomic, strong) GMSMapView *mapView;
+@property (strong, nonatomic) IBOutlet UIButton *checkInButton;
 @end
 
 NS_ASSUME_NONNULL_END

--- a/ThrowIT/ViewControllers/DetailsViewController.h
+++ b/ThrowIT/ViewControllers/DetailsViewController.h
@@ -8,6 +8,8 @@
 #import <UIKit/UIKit.h>
 #import "Party.h"
 #import <GoogleMaps/GoogleMaps.h>
+#import "Check In.h"
+#import "APIManager.h"
 
 NS_ASSUME_NONNULL_BEGIN
 

--- a/ThrowIT/ViewControllers/DetailsViewController.h
+++ b/ThrowIT/ViewControllers/DetailsViewController.h
@@ -12,11 +12,17 @@
 #import "APIManager.h"
 
 NS_ASSUME_NONNULL_BEGIN
+@protocol DetailsViewControllerDelegate <NSObject>
+
+-(void)reloadCells;
+
+@end
 
 @interface DetailsViewController : UIViewController
 @property (nonatomic, strong) Party *party;
 @property (nonatomic, strong) GMSMapView *mapView;
 @property (strong, nonatomic) IBOutlet UIButton *checkInButton;
+@property (nonatomic, weak) id<DetailsViewControllerDelegate> delegate;
 @end
 
 NS_ASSUME_NONNULL_END

--- a/ThrowIT/ViewControllers/DetailsViewController.m
+++ b/ThrowIT/ViewControllers/DetailsViewController.m
@@ -61,7 +61,14 @@
                     NSNumberFormatter *f = [[NSNumberFormatter alloc] init];
                     f.numberStyle = NSNumberFormatterDecimalStyle;
                     if(1.0 >= [[f numberFromString:[distance componentsSeparatedByString:SPACE][0]] doubleValue] || [[distance componentsSeparatedByString:SPACE][1] isEqualToString:FEET]){
-                        [Check_In postNewCheckInForParty:self.party withCompletion:^(BOOL succeeded, NSError * _Nullable error) {}];   //checkin
+                        [Check_In postNewCheckInForParty:self.party withCompletion:^(BOOL succeeded, NSError * _Nullable error) {}];
+                        PFUser *user = [PFUser currentUser];
+                        [user fetchInBackgroundWithBlock:^(PFObject * _Nullable object, NSError * _Nullable error) {
+                            int partiesAttendedCount = [user[PARTIESATTENDEDKEY] intValue];
+                            partiesAttendedCount += 1;
+                            user[PARTIESATTENDEDKEY] = [NSNumber numberWithInt:partiesAttendedCount];
+                            [user saveInBackground];
+                        }];
                         dispatch_async(dispatch_get_main_queue(), ^{
                             self.checkInButton.layer.backgroundColor = [[UIColor greenColor] CGColor];
                             self.checkInButton.userInteractionEnabled = NO;

--- a/ThrowIT/ViewControllers/DetailsViewController.m
+++ b/ThrowIT/ViewControllers/DetailsViewController.m
@@ -61,7 +61,9 @@
                     NSNumberFormatter *f = [[NSNumberFormatter alloc] init];
                     f.numberStyle = NSNumberFormatterDecimalStyle;
                     if(1.0 >= [[f numberFromString:[distance componentsSeparatedByString:SPACE][0]] doubleValue] || [[distance componentsSeparatedByString:SPACE][1] isEqualToString:FEET]){
-                        [Check_In postNewCheckInForParty:self.party withCompletion:^(BOOL succeeded, NSError * _Nullable error) {}];
+                        [Check_In postNewCheckInForParty:self.party withCompletion:^(BOOL succeeded, NSError * _Nullable error) {
+                            [self.delegate reloadCells];
+                        }];
                         PFUser *user = [PFUser currentUser];
                         [user fetchInBackgroundWithBlock:^(PFObject * _Nullable object, NSError * _Nullable error) {
                             int partiesAttendedCount = [user[PARTIESATTENDEDKEY] intValue];

--- a/ThrowIT/ViewControllers/DetailsViewController.m
+++ b/ThrowIT/ViewControllers/DetailsViewController.m
@@ -16,7 +16,7 @@
 @implementation DetailsViewController
 - (void)viewDidLoad {
     [super viewDidLoad];
-    self.partyNameLabel.text = self.party.name;
+    [self loadPartyDetails];
     [self showMap];
 }
 - (IBAction)goToMapDirections:(id)sender {
@@ -36,4 +36,31 @@
     GMSMarker *marker = [GMSMarker markerWithPosition:mapCenter];
     marker.map = self.mapView;
 }
+
+-(void)loadPartyDetails{
+    self.partyNameLabel.text = self.party.name;
+    if([[NSDate now] earlierDate:self.party.startTime] == self.party.startTime && [[NSDate now] laterDate:self.party.endTime] == self.party.endTime){
+        self.checkInButton.hidden = false;
+    }
+    else{
+        self.checkInButton.hidden = true;
+        //if check in already happened(save checkin to parse)
+            //make button filler green and unclickable
+        //else
+            //make button filler transparent
+    }
+}
+
+- (IBAction)didTapCheckIn:(id)sender {
+    //if check in hasn't already happened
+        //if location is within 2 miles of party location
+            //checkin
+            //turn button green
+        //else
+            //display error message
+    //else
+        //do nothing
+        //display message that they already checked in
+}
+
 @end

--- a/ThrowIT/ViewControllers/DetailsViewController.m
+++ b/ThrowIT/ViewControllers/DetailsViewController.m
@@ -39,7 +39,7 @@
 
 -(void)loadPartyDetails{
     self.partyNameLabel.text = self.party.name;
-    if([[NSDate now] earlierDate:self.party.startTime] == self.party.startTime && [[NSDate now] laterDate:self.party.endTime] == self.party.endTime){
+    if([self.party isGoingOn]){
         self.checkInButton.hidden = false;
     }
     else{

--- a/ThrowIT/ViewControllers/DetailsViewController.m
+++ b/ThrowIT/ViewControllers/DetailsViewController.m
@@ -68,20 +68,17 @@
                         });
                     }
                     else{
-                        NSLog(@"User too far from check in");
-                        //TODO: display user too far from party
+                        //TODO: display user too far from party: @"User too far from party to check in"
                     }
                 }];
             }
             else{
-                NSLog(@"User already checked in");
-                //TODO: display already checked in message
+                //TODO: display already checked in message: @"User already checked in"
             }
         }];
     }
     else{
-        NSLog(@"The party already ended");
-        //TODO: display party over message
+        //TODO: display party over message: @"The party already ended"
     }
 }
 

--- a/ThrowIT/ViewControllers/ThrowerTimelineViewController.m
+++ b/ThrowIT/ViewControllers/ThrowerTimelineViewController.m
@@ -110,8 +110,8 @@
     Party *party = self.throwerPartyList[indexPath.section];
     throwerPartyCell.partyName.text = party.name;
     throwerPartyCell.partyDescription.text = party.partyDescription;
-    throwerPartyCell.partyImageView.layer.cornerRadius = 10;
-    throwerPartyCell.partyImageView.layer.borderWidth = 0.1;
+    throwerPartyCell.layer.cornerRadius = 10;
+    throwerPartyCell.layer.borderWidth = 0.1;
     [throwerPartyCell.partyImageView setImage:[UIImage imageNamed:PARTYIMAGEDEFAULT]];
     [self partyGoingCountQuery:party withPartyCell:throwerPartyCell];
     return throwerPartyCell;

--- a/ThrowIT/ViewControllers/ThrowerTimelineViewController.m
+++ b/ThrowIT/ViewControllers/ThrowerTimelineViewController.m
@@ -112,7 +112,12 @@
     throwerPartyCell.partyDescription.text = party.partyDescription;
     throwerPartyCell.layer.cornerRadius = 10;
     throwerPartyCell.layer.borderWidth = 0.1;
-    [throwerPartyCell.partyImageView setImage:[UIImage imageNamed:PARTYIMAGEDEFAULT]];
+    if(party.partyPhoto == nil)
+        [throwerPartyCell.partyImageView setImage:[UIImage imageNamed:PARTYIMAGEDEFAULT]];
+    else{
+        throwerPartyCell.partyImageView.file = party.partyPhoto;
+        [throwerPartyCell.partyImageView loadInBackground];
+    }
     [self partyGoingCountQuery:party withPartyCell:throwerPartyCell];
     return throwerPartyCell;
 }

--- a/ThrowIT/ViewControllers/TimelineViewController.m
+++ b/ThrowIT/ViewControllers/TimelineViewController.m
@@ -74,6 +74,7 @@
         Party *party = self.filteredList[myIndexPath.item];
         DetailsViewController *detailsController = [segue destinationViewController];
         detailsController.party = party;
+        detailsController.delegate = self;
     }
     else if([[segue identifier] isEqualToString:DETAILSVIEWCONTROLLERFORTABLECELL]){
         UITableViewCell *partyCell = sender;
@@ -82,6 +83,7 @@
         Party *party = self.filteredList[myIndexPath.section + SHIFTNUMBER];
         DetailsViewController *detailsController = [segue destinationViewController];
         detailsController.party = party;
+        detailsController.delegate = self;
     }
     else if([[segue identifier] isEqualToString:FILTERSEGUE]){
         UINavigationController *partyFilterNavigationController = [segue destinationViewController];
@@ -125,6 +127,11 @@
             [self.collectionView reloadData];
         }
     }];
+}
+
+-(void)reloadCells{
+    [self.collectionView reloadData];
+    [self.tableView reloadData];
 }
 
 #pragma mark - UITableViewDataSource
@@ -179,6 +186,12 @@
         else{
             NSLog(@"%@", error.localizedDescription);
         }
+    }];
+    [Check_In userIsCheckedIn:party withCompletion:^(BOOL checkInExists) {
+        if(checkInExists)
+            partyCell.checkInTag.hidden = false;
+        else
+            partyCell.checkInTag.hidden = true;
     }];
     [self partyGoingCountQuery:party withPartyCell:partyCell orWithTopPartyCell:nil];
     return partyCell;
@@ -302,6 +315,12 @@
         else{
             NSLog(@"%@", error.localizedDescription);
         }
+    }];
+    [Check_In userIsCheckedIn:party withCompletion:^(BOOL checkInExists) {
+        if(checkInExists)
+            topPartyCell.checkInTag.hidden = false;
+        else
+            topPartyCell.checkInTag.hidden = true;
     }];
     [self partyGoingCountQuery:party withPartyCell:nil orWithTopPartyCell:topPartyCell];
     return topPartyCell;


### PR DESCRIPTION
 ## Description
- Users can now check in and record their attendance by clicking on a "Check In" button.
- Users only see the "Check In" button if the party is currently on going.
- Check In is only registered if the user is within 1 mile of the party location.
- Throwers can only set logical dates for parties(start time greater than current time, and end time greater than start time)
- In a seperate branch and PR dedicated to creating a utility error alert object, I will handle errors across the app to be shown to users who:
  - try clicking the button after already checking in
  - check in outside the required distance.
  - stay on the details view and try to check in after the party is over.
  - trigger other error alerts related to features from other PRs in the app
## Milestones
- Stretch feature- Recording party attendance.

## Test Plan
[Here's](https://drive.google.com/file/d/18j5MHIi_jYhHV2nvM_hNVKkrrB79K-EM/view?usp=sharing) a video showcasing the above changes. To show "Check In" button visibility functions as expected, I first click on a party that is not ongoing. Secondly, I click on a party that is ongoing, but too far from the user to allow a check in. I click on the button multiple times but it fails to register a check in. Finally I click on a party that satisfies both requirements and get a button color change to verify that the user is checked in.